### PR TITLE
Fix: Level ends only on reaching exit tile

### DIFF
--- a/doomgame.html
+++ b/doomgame.html
@@ -1841,6 +1841,8 @@
                 }); 
 
                 // Level completion check for regular levels (non-boss, non-mini-boss)
+                /* // MODIFIED BY JULES: This logic is removed to prevent level completion just by killing all enemies.
+                   // Level completion should only happen when the player reaches the TILE_EXIT.
                 if (!isBossLevel && !isCurrentLevelMiniBoss && enemiesRemaining <= 0 && enemiesSpawnedThisLevel >= enemiesToSpawnPerLevel) {
                     if (!isLevelCompleting) { 
                          let exitTileExists = false;
@@ -1856,6 +1858,7 @@
                          else console.log("All regular enemies cleared, but no exit tile found on map.");
                     }
                 }
+                */
             } catch (e) {
                 console.error("Error in update function:", e, e.stack);
                 gameRunning = false; 


### PR DESCRIPTION
Previously, regular levels would end if all enemies were defeated, regardless of whether the player had reached the exit tile.

This change comments out the logic that triggered level completion based on enemy count, ensuring that levels now only complete when the player character interacts with the TILE_EXIT or when a boss/mini-boss is defeated (which is existing, correct behavior).